### PR TITLE
[FIX] Prevent cursor blinking during playwright tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,10 +79,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+
     - uses: actions/download-artifact@v4
       with:
         name: extension-artifacts
@@ -112,6 +114,23 @@ jobs:
       uses: actions/upload-pages-artifact@v3
       with:
         path: ./lite/dist
+
+    # Overwrite some settings to disable cursor blinking,
+    # which causes inadvertent playwright snapshot failures
+    - name: Build the JupyterLite app (in test mode)
+      run: |
+        cd lite
+        rm -r dist # jupyter lite will not build in `dist-test/` if `dist/` exists...?
+        cat jupyter-lite.json | jq '.["jupyter-config-data"].["settingsOverrides"] += {"@jupyterlab/codemirror-extension:plugin":{ "defaultConfig": { "cursorBlinkRate": 0 } }, "@jupyterlab/terminal-extension:plugin": { "cursorBlink": false } }' > jupyter-lite.json.tmp
+        mv jupyter-lite.json.tmp jupyter-lite.json
+        jupyter lite build --output-dir dist-test
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: lite-app-test
+        path: ./lite/dist-test
+        if-no-files-found: error
 
     - name: Leave instructions for testing
       run: |
@@ -187,10 +206,10 @@ jobs:
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-    - name: Download extension package
+    - name: Download lite app (test mode)
       uses: actions/download-artifact@v4
       with:
-        name: lite-app
+        name: lite-app-test
         path: dist
 
     - name: Install jlpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       run: |
         cd lite
         rm -r dist # jupyter lite will not build in `dist-test/` if `dist/` exists...?
-        cat jupyter-lite.json | jq '.["jupyter-config-data"].["settingsOverrides"] += {"@jupyterlab/codemirror-extension:plugin":{ "defaultConfig": { "cursorBlinkRate": 0 } }, "@jupyterlab/terminal-extension:plugin": { "cursorBlink": false } }' > jupyter-lite.json.tmp
+        cat jupyter-lite.json | jq '.["jupyter-config-data"].["settingsOverrides"] += {"@jupyterlab/codemirror-extension:plugin":{ "defaultConfig": { "cursorBlinkRate": 0 } } }' > jupyter-lite.json.tmp
         mv jupyter-lite.json.tmp jupyter-lite.json
         jupyter lite build --output-dir dist-test
 


### PR DESCRIPTION
Closes #47 by overriding settings to prevent the cursor from blinking, which is currently causing playwright test failures.

Note:
- `jq` can't be used to in-place rewrite files, so I had to shuffle temporary files
- Building with jupyter lite build --output-dir dist/ and then jupyter lite build --output-dir dist-test/ fails! Interestingly if you remove dist/ before trying to build inside dist-test/, the build works just fine. Upstream bug?

