### PR TITLE
Prevent a race condition between manual sharing and the save handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
           await handleNotebookSharing(notebookPanel, sharingService, true);
         } catch (error) {
           console.error('Error in share command:', error);
+        } finally {
+          if (tracker.currentWidget) {
+            manuallySharing.delete(tracker.currentWidget);
+          }
         }
       }
     });


### PR DESCRIPTION
This PR drops the notebook from the `manuallySharing` set when it's saved to the sharing service; it's something I missed as part of #64. Here is a scenario where this is useful:

1. The student clicks on the "Share" button
2. We then add their notebook to the `manuallySharing` set
3. We call `await notebookPanel.context.save()` to save the notebook
4. This save triggers the auto-sync handler (i.e., the notebook is saved to our sharing service), because `saveState === 'completed'`
5. However, we don't want the notebook saving operation to run during the time of the manual sharing's save operation (both operations may try to update `notebookContent.metadata` simultaneously, the API responses may arrive out of order especially if performing the save/calling the API takes longer than usual, last-writer-wins scenario, etc.)

If we don't do this, future saves could be permanently broken, as the notebook would stay in the `manuallySharing` set forever. Hence, every future save would skip auto-sync. There's also a potential memory leak here; although I'm not too well-versed in this, the `WeakSet` helps, but it's still better to clean up. Would I be correct here with this change, or is this PR not needed?