### PR TITLE
Use `memoryStorageDriver`

### DIFF
--- a/lite/jupyter-lite.json
+++ b/lite/jupyter-lite.json
@@ -4,6 +4,8 @@
     "appName": "Jupyter Everywhere",
     "exposeAppInBrowser": true,
     "showLoadingIndicator": true,
+    "enableMemoryStorage": true,
+    "contentsStorageDrivers": "memoryStorageDriver",
     "settingsOverrides": {
       "@jupyterlab/mainmenu-extension:plugin": {
         "menus": [


### PR DESCRIPTION
I think it is time now that we do this. This PR sets the storage to `memoryStorageDriver` (in-memory, non-persistent). Files uploaded to the Files widget and notebooks will not retain data if saved beforehand when reloaded because `enableMemoryStorage` is also `true`.

Reference: https://jupyterlite.readthedocs.io/en/latest/howto/configure/storage.html