### PR TITLE
Drop `setup.py` from the extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,1 +1,0 @@
-__import__("setuptools").setup()


### PR DESCRIPTION
We use `hatchling` as the build backend, which is not reliant on it.