### PR TITLE
Add `jupytereverywhere:save-and-share` command to display shareable links when saving a notebook through key bindings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,36 @@ const plugin: JupyterFrontEndPlugin<void> = {
       }
     });
     /**
+     * Add a custom Save and Share notebook command. This command
+     * is activated only on key bindings (Accel S) and is used to
+     * display the shareable link dialog after the notebook is
+     * saved manually by the user.
+     */
+    commands.addCommand('jupytereverywhere:save-and-share', {
+      label: 'Save and Share Notebook',
+      execute: async () => {
+        const panel = readonlyTracker.currentWidget ?? tracker.currentWidget;
+        if (!panel) {
+          console.warn('No active notebook to save');
+          return;
+        }
+        if (panel.context.model.readOnly) {
+          console.info('Notebook is read-only, skipping save-and-share.');
+          return;
+        }
+        manuallySharing.add(panel);
+        await panel.context.save();
+        await handleNotebookSharing(panel, sharingService, true);
+      }
+    });
+
+    app.commands.addKeyBinding({
+      command: 'jupytereverywhere:save-and-share',
+      keys: ['Accel S'],
+      selector: '.jp-Notebook'
+    });
+
+    /**
      * Add custom Create Copy notebook command
      * Note: this command is supported and displayed only for View Only notebooks.
      */

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -12,7 +12,7 @@ declare global {
 async function runCommand(page: Page, command: string, args: JSONObject = {}) {
   await page.evaluate(
     async ({ command, args }) => {
-      await window.jupyterapp.commands.execute(command, args);
+      window.jupyterapp.commands.execute(command, args);
     },
     { command, args }
   );
@@ -173,6 +173,15 @@ test.describe('Sharing', () => {
     await expect(dialog).toHaveCount(0);
     await shareButton.click();
     await expect(dialog).toHaveCount(1);
+  });
+
+  test('Should show share dialog on Accel+S in interactive notebook', async ({ page }) => {
+    await mockTokenRoute(page);
+    await mockShareNotebookResponse(page, 'e3b0c442-98fc-1fc2-9c9f-8b6d6ed08a1d');
+    await runCommand(page, 'jupytereverywhere:save-and-share');
+    const dialog = page.locator('.jp-Dialog-content');
+    await expect(dialog).toBeVisible();
+    expect(await dialog.screenshot()).toMatchSnapshot('share-dialog.png');
   });
 });
 


### PR DESCRIPTION
This PR adds a command that uses `Accel S` to display the share dialogue when the save keybindings are pressed. It is shown on writable notebooks. This is because when trying to perform the save operation through the key bindings on View Only notebooks, which already have the "not writable", we have an alert that shows up in the bottom right of the screen.

This new command only hooks into manual saving, i.e., when the key bindings are pressed. If we were to hook into the `saveState` signal handler, as we already do for saving to CKHub, the share dialogue would keep popping up on autosaves, which would be pretty annoying.

Closes #60