### PR TITLE
Update type definitions for readable IDs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ const manuallySharing = new WeakSet<NotebookPanel | ViewOnlyNotebookPanel>();
  */
 async function showShareDialog(sharingService: SharingService, notebookContent: INotebookContent) {
   // Grab the readable ID, or fall back to the UUID.
-  const readableID = notebookContent.metadata?.readableId as string | null;
+  const readableID = notebookContent.metadata?.readableId as string;
   const sharedID = notebookContent.metadata?.sharedId as string;
 
   const notebookID = readableID ?? sharedID;

--- a/src/sharing-service.ts
+++ b/src/sharing-service.ts
@@ -19,7 +19,7 @@ export interface IShareResponse {
   message: string;
   notebook: {
     id: UUID;
-    readable_id: string | null;
+    readable_id: string;
   };
 }
 
@@ -29,7 +29,7 @@ export interface IShareResponse {
 export interface INotebookResponse {
   id: UUID;
   domain_id: string;
-  readable_id: string | null;
+  readable_id: string;
   content: INotebookContent;
 }
 
@@ -108,11 +108,6 @@ function validateShareResponse(data: unknown): data is IShareResponse {
     return false;
   }
 
-  // readable_id can be null or string
-  if (response.notebook.readable_id !== null && typeof response.notebook.readable_id !== 'string') {
-    return false;
-  }
-
   return true;
 }
 
@@ -141,11 +136,6 @@ function validateNotebookResponse(data: unknown): data is INotebookResponse {
   }
 
   if (typeof response.domain_id !== 'string') {
-    return false;
-  }
-
-  // readable_id can be null or string
-  if (response.readable_id !== null && typeof response.readable_id !== 'string') {
     return false;
   }
 


### PR DESCRIPTION
We now have readable IDs coming from the sharing service, so this PR updates some type definitions that are now outdated.

Closes #67 