### PR TITLE
Install `micromamba` for the build and snapshots jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,9 @@ jobs:
       with:
         python-version: '3.11'
 
+    - name: Install micromamba
+      uses: mamba-org/setup-micromamba@b09ef9b599704322748535812ca03efb2625677b # v2.0.5
+
     - uses: actions/download-artifact@v4
       with:
         name: extension-artifacts

--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
+      - name: Install micromamba
+        uses: mamba-org/setup-micromamba@b09ef9b599704322748535812ca03efb2625677b # v2.0.5
+
       - name: Install jlpm
         run: python -m pip install -U "jupyterlab>=4.0.0,<5"
 


### PR DESCRIPTION
In #115, I'm trying to integrate the Xeus kernel, but the Playwright snapshots jobs run from an older state of the workflow, and they hence fail because micromamba isn't present in https://github.com/JupyterEverywhere/jupyterlite-extension/commit/7f0de86552fec28b56a281752f30c90bfb96108f. This PR sets up `micromamba` so that the JupyterLite build can succeed.