### PR TITLE
Disable context menus for `application-extension`

### DIFF
--- a/lite/jupyter-lite.json
+++ b/lite/jupyter-lite.json
@@ -47,6 +47,9 @@
       "@jupyterlab/notebook-extension:tracker": {
         "autoStartDefaultKernel": true,
         "windowingMode": "none"
+      },
+      "@jupyterlab/application-extension:context-menu": {
+        "disabled": true
       }
     },
     "disabledExtensions": [


### PR DESCRIPTION
This disables the "Switch Sidebar Side" buttons in #107, such that right-clicking on the sidebar now does nothing. This option was enabled starting with JupyterLab 4.4+, which we already support in JupyterLite 0.6.

Closes #107