### PR TITLE
Add missing permissions for `github-script` action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,10 @@ jobs:
   lite:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
 
     steps:
     - name: Checkout


### PR DESCRIPTION
As the script reads and writes comments, and updates existing comments, this permission is also required.