### PR TITLE
Fix netlify deploy on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,8 +156,6 @@ jobs:
       run: |
         echo "### JupyterLite App is ready" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "To test on netlify: ${{ steps.deploy_preview.outputs.NETLIFY_URL }}" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
         echo 'To test it locally, download the `lite-app` artifact and run' >> $GITHUB_STEP_SUMMARY
         echo '```bash' >> $GITHUB_STEP_SUMMARY
         echo "rm -r lite-app" >> $GITHUB_STEP_SUMMARY
@@ -185,7 +183,19 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        
+
+  deploy-netlify:
+    needs: lite
+    if: github.ref == 'refs/heads/main'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download lite app
+        uses: actions/download-artifact@v4
+        with:
+          name: lite-app
+          path: dist
+    
       - name: Publish to Netlify
         uses: netlify/actions/cli@3185065f4ab2f6df6f2ef41ee013626e1c02a426
         with:
@@ -193,6 +203,7 @@ jobs:
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+
 
   test_isolated:
     needs: build


### PR DESCRIPTION
Looking at jobs on `main`, the deployment did not go through:

<img width="779" height="1203" alt="image" src="https://github.com/user-attachments/assets/f24f0928-c75c-4865-9b52-acca6f95ad4d" />

Trying again. Also removing old netlify URL summary bit.