### PR TITLE
Switch to the `xeus-python` kernel

### DIFF
--- a/lite/requirements.txt
+++ b/lite/requirements.txt
@@ -1,3 +1,2 @@
-jupyterlite==0.6.0rc0
-jupyterlite-pyodide-kernel==0.6.0rc0
+jupyterlite==0.6.3
 jupyterlite-xeus==4.0.5

--- a/lite/xeus-environment.yml
+++ b/lite/xeus-environment.yml
@@ -1,4 +1,4 @@
-name: xeus-kernel
+name: xeus-kernels
 channels:
   - https://repo.prefix.dev/emscripten-forge-dev
   - https://repo.prefix.dev/conda-forge

--- a/lite/xeus-environment.yml
+++ b/lite/xeus-environment.yml
@@ -3,4 +3,5 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
   - https://repo.prefix.dev/conda-forge
 dependencies:
+  - xeus-python
   - xeus-r

--- a/src/kernels.ts
+++ b/src/kernels.ts
@@ -1,7 +1,7 @@
 import { NotebookPanel } from '@jupyterlab/notebook';
 
 export const KERNEL_DISPLAY_NAMES: Record<string, string> = {
-  python: 'Python',
+  xpython: 'Python',
   xr: 'R'
 };
 

--- a/src/landing.tsx
+++ b/src/landing.tsx
@@ -52,7 +52,7 @@ function LandingPage(): JSX.Element {
           </h1>
 
           <div className="je-buttons">
-            <a href="lab/index.html?kernel=python" className="je-card">
+            <a href="lab/index.html?kernel=xpython" className="je-card">
               <p>Create Python Notebook</p>
               <img src={pythonLogo} alt="Python logo" />
             </a>

--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -123,7 +123,7 @@ export const notebookPlugin: JupyterFrontEndPlugin<void> = {
     const createNewNotebook = async (): Promise<void> => {
       try {
         const params = new URLSearchParams(window.location.search);
-        const desiredKernel = params.get('kernel') || 'python';
+        const desiredKernel = params.get('kernel') || 'xpython';
 
         await commands.execute('notebook:create-new', {
           kernelName: desiredKernel

--- a/src/ui-components/KernelSwitcherDropdownButton.tsx
+++ b/src/ui-components/KernelSwitcherDropdownButton.tsx
@@ -73,7 +73,7 @@ export class KernelSwitcherDropdownButton extends ReactWidget {
   private _showMenu(): void {
     const currentKernel = this._tracker.currentWidget?.sessionContext.session?.kernel?.name;
 
-    const allKernels = ['python', 'xr'];
+    const allKernels = ['xpython', 'xr'];
 
     // We order the kernels, so that the current kernel appears first
     // in the dropdown.

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -31,9 +31,9 @@ const PYTHON_TEST_NOTEBOOK: JSONObject = {
   ],
   metadata: {
     kernelspec: {
-      display_name: 'Python 3 (ipykernel)',
+      display_name: 'Python 3.13 (XPython)',
       language: 'python',
-      name: 'python3'
+      name: 'xpython'
     },
     language_info: {
       codemirror_mode: {

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -354,7 +354,7 @@ test.describe('Landing page', () => {
     page
   }) => {
     await page.goto('index.html');
-    await page.click('a[href*="kernel=python"]');
+    await page.click('a[href*="kernel=xpython"]');
     await page.waitForSelector('.jp-NotebookPanel');
 
     const kernelLabel = await page.locator('.je-KernelSwitcherButton').innerText();


### PR DESCRIPTION
in lieu of the Pyodide kernel; bringing a slightly older version of Emscripten but more frequent package updates and a faster kernel. The advantage that the Pyodide kernel has is its (1) lockfiles, but we haven't updated the Pyodide kernel to 0.28 yet, and (2) we update the core packages in the SciPy stack more often. However, the xeus-python kernel provides faster solves, so this should be fine for our usage.

Closes #143