### PR TITLE
Skip CKHub sync for view-only notebooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,10 +86,19 @@ async function handleNotebookSharing(
 ) {
   const notebookContent = notebookPanel.context.model.toJSON() as INotebookContent;
 
+  const isViewOnly = notebookContent.metadata?.isSharedNotebook === true;
   const sharedId = notebookContent.metadata?.sharedId as string | undefined;
   const defaultName = generateDefaultNotebookName();
 
   try {
+    if (isViewOnly) {
+      // Skip CKHub sync for view-only notebooks
+      console.log('View-only notebook: skipping CKHub sync and showing share URL.');
+      if (manual) {
+        await showShareDialog(sharingService, notebookContent);
+      }
+      return;
+    }
     if (sharedId) {
       console.log('Updating notebook:', sharedId);
       await sharingService.update(sharedId, notebookContent);


### PR DESCRIPTION
Closes #126; the fix is self-explanatory – we bypass the CKHub sharing action if the notebook metadata indicates that it is a shared one and display the share dialogue directly (which also retrieves the readable ID from the notebook). I've tested this locally because #52 has not been resolved yet.