### PR TITLE
Add custom commands that use "memory" terminology instead of the word "kernel"

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -58,7 +58,9 @@
       },
       {
         "name": "restart",
-        "caption": "Restart notebook"
+        "command": "jupytereverywhere:restart-memory",
+        "caption": "Restart notebook",
+        "label": ""
       },
       {
         "name": "restart-and-run",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -64,7 +64,8 @@
       },
       {
         "name": "restart-and-run",
-        "caption": "Restart and run all cells"
+        "caption": "Restart and run all cells",
+        "command": "jupytereverywhere:restart-and-run-all"
       },
       {
         "name": "share",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,4 +6,5 @@ export namespace Commands {
   export const downloadPDFCommand = 'jupytereverywhere:download-pdf';
   export const shareNotebookCommand = 'jupytereverywhere:share-notebook';
   export const createCopyNotebookCommand = 'jupytereverywhere:create-copy-notebook';
+  export const restartMemoryCommand = 'jupytereverywhere:restart-memory';
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,4 +7,5 @@ export namespace Commands {
   export const shareNotebookCommand = 'jupytereverywhere:share-notebook';
   export const createCopyNotebookCommand = 'jupytereverywhere:create-copy-notebook';
   export const restartMemoryCommand = 'jupytereverywhere:restart-memory';
+  export const restartMemoryAndRunAllCommand = 'jupytereverywhere:restart-and-run-all';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { createSuccessDialog, createErrorDialog } from './ui-components/share-di
 
 import { LabIcon } from '@jupyterlab/ui-components';
 import refreshIcon from '../style/icons/refresh.svg';
-import fastForwardSvg from './style/icons/fast-forward.svg';
+import fastForwardSvg from '../style/icons/fast-forward.svg';
 
 import { exportNotebookAsPDF } from './pdf';
 import { files } from './pages/files';

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
       }
     });
 
+    /**
+     * Add a command to restart the notebook kernel, terming it as "memory"
+     */
     const RefreshLabIcon = new LabIcon({
       name: 'jupytereverywhere:refresh',
       svgstr: refreshIcon
@@ -236,6 +239,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
       }
     });
 
+    /**
+     * Add a command to restart the notebook kernel, terming it as "memory",
+     * and run all cells after the restart.
+     */
     const customFastForwardIcon = new LabIcon({
       name: 'jupytereverywhere:restart-run',
       svgstr: fastForwardSvg

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
           try {
             await panel.sessionContext.restartKernel();
           } catch (err) {
-            console.error('Kernel restart failed', err);
+            console.error('Memory restart failed', err);
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { createSuccessDialog, createErrorDialog } from './ui-components/share-di
 
 import { LabIcon } from '@jupyterlab/ui-components';
 import refreshIcon from '../style/icons/refresh.svg';
+import fastForwardSvg from './style/icons/fast-forward.svg';
 
 import { exportNotebookAsPDF } from './pdf';
 import { files } from './pages/files';
@@ -230,6 +231,38 @@ const plugin: JupyterFrontEndPlugin<void> = {
             await panel.sessionContext.restartKernel();
           } catch (err) {
             console.error('Kernel restart failed', err);
+          }
+        }
+      }
+    });
+
+    const customFastForwardIcon = new LabIcon({
+      name: 'jupytereverywhere:restart-run',
+      svgstr: fastForwardSvg
+    });
+
+    commands.addCommand(Commands.restartMemoryAndRunAllCommand, {
+      label: 'Restart Notebook Memory and Run All Cells',
+      icon: customFastForwardIcon,
+      isEnabled: () => !!tracker.currentWidget,
+      execute: async () => {
+        const panel = tracker.currentWidget;
+        if (!panel) {
+          console.warn('No active notebook to restart and run.');
+          return;
+        }
+
+        const result = await showDialog({
+          title: 'Would you like to restart the notebook’s memory and rerun all cells?',
+          buttons: [Dialog.cancelButton({ label: 'Cancel' }), Dialog.okButton({ label: 'Restart' })]
+        });
+
+        if (result.button.accept) {
+          try {
+            await panel.sessionContext.restartKernel();
+            await commands.execute('notebook:run-all-cells');
+          } catch (err) {
+            console.error('Restarting and running all cells failed', err);
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@ import { SharingService } from './sharing-service';
 
 import { createSuccessDialog, createErrorDialog } from './ui-components/share-dialog';
 
+import { LabIcon } from '@jupyterlab/ui-components';
+import refreshIcon from '../style/icons/refresh.svg';
+
 import { exportNotebookAsPDF } from './pdf';
 import { files } from './pages/files';
 import { Commands } from './commands';
@@ -198,6 +201,36 @@ const plugin: JupyterFrontEndPlugin<void> = {
             body: ReactWidget.create(createErrorDialog(error)),
             buttons: [Dialog.okButton()]
           });
+        }
+      }
+    });
+
+    const RefreshLabIcon = new LabIcon({
+      name: 'jupytereverywhere:refresh',
+      svgstr: refreshIcon
+    });
+
+    commands.addCommand(Commands.restartMemoryCommand, {
+      label: 'Restart Notebook Memory',
+      icon: RefreshLabIcon,
+      execute: async () => {
+        const panel = tracker.currentWidget;
+        if (!panel) {
+          console.warn('No active notebook to restart.');
+          return;
+        }
+
+        const result = await showDialog({
+          title: 'Would you like to restart the notebook’s memory?',
+          buttons: [Dialog.cancelButton({ label: 'Cancel' }), Dialog.okButton({ label: 'Restart' })]
+        });
+
+        if (result.button.accept) {
+          try {
+            await panel.sessionContext.restartKernel();
+          } catch (err) {
+            console.error('Kernel restart failed', err);
+          }
         }
       }
     });

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -559,3 +559,27 @@ test.describe('Title of the pages should be "Jupyter Everywhere"', () => {
     expect(title).toBe('Jupyter Everywhere');
   });
 });
+
+test.describe('Kernel commands should use memory terminology', () => {
+  test('Restart memory command', async ({ page }) => {
+    const promise = runCommand(page, 'jupytereverywhere:restart-memory');
+    const dialog = page.locator('.jp-Dialog-content');
+
+    await expect(dialog).toBeVisible();
+    expect(await dialog.screenshot()).toMatchSnapshot('restart-memory-dialog.png');
+
+    await dialog.press('Escape');
+    await promise;
+  });
+
+  test('Restart memory and run all cells command', async ({ page }) => {
+    const promise = runCommand(page, 'jupytereverywhere:restart-and-run-all');
+    const dialog = page.locator('.jp-Dialog-content');
+
+    await expect(dialog).toBeVisible();
+    expect(await dialog.screenshot()).toMatchSnapshot('restart-memory-run-all-dialog.png');
+
+    await dialog.press('Escape');
+    await promise;
+  });
+});


### PR DESCRIPTION
### Description

This PR adds two commands that we use in favour of the default kernel reloading mechanisms: `jupytereverywhere:restart-memory` (tied to the "Refresh" icon) and `jupytereverywhere:restart-and-run-all` (tied to the "Fast forward" icon). The former only restarts the kernel, and the latter restarts the kernel and executes cells. Both of them open dialogues that display "memory" wording rather than kernels.

Closes #82

### Screenshots

| Command | Dialogue displayed |
|:-------|:------:|
| `jupytereverywhere:restart-memory` | <img width="5088" height="3032" alt="image" src="https://github.com/user-attachments/assets/f297e85f-67bd-4fbe-b906-9fe48f6bda25" /> |
| `jupytereverywhere:restart-and-run-all` | <img width="5088" height="3032" alt="image" src="https://github.com/user-attachments/assets/e9fee235-75bd-4ddc-8913-01f909f88b22" /> | 

