### PR TITLE
Drop `persist-credentials` input for snapshots job checkout

### DIFF
--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
 
       - name: Get PR Info
         id: pr


### PR DESCRIPTION
In #137, we did not attempt to run the snapshots (as there was no need), but I believe they require credentials to execute, otherwise they fail with logs like these: https://github.com/JupyterEverywhere/jupyterlite-extension/actions/runs/16441009698/workflow?pr=156