### PR TITLE
Fix the artifact name to upload for the Netlify deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,9 +206,9 @@ jobs:
       - name: Download lite app
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: lite-app
+          name: lite-app-prod
           path: dist
-    
+
       - name: Publish to Netlify
         uses: netlify/actions/cli@3185065f4ab2f6df6f2ef41ee013626e1c02a426 # 3185065f4ab2f6df6f2ef41ee013626e1c02a426
         with:


### PR DESCRIPTION
This PR fixes the artifact name to use the one that was changed in #161, I forgot to change this one there :)

I noticed this from the failing deployment on `main`: https://github.com/JupyterEverywhere/jupyterlite-extension/actions/runs/16477364346/job/46582887288