### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ],
     "homepage": "",
     "bugs": {
-        "url": "/issues"
+        "url": "https://github.com/JupyterEverywhere/jupyterlite-extension/issues"
     },
     "license": "BSD-3-Clause",
     "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupytereverywhere",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "A Jupyter extension for k12 education",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
This PR bumps the version to `1.0.0` ahead of a release. We'll be using SemVer going forward, and 1.0.0 sounds to me like the right way to demarcate this.