### PR TITLE
Bump TypeScript to `5.1.6` to work around `@types/jsdoc` compilation issue

### DIFF
--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -87,7 +87,6 @@ jobs:
       - name: Install extension
         run: |
           set -eux
-          jlpm
           python -m pip install .
 
       - name: Build landing page and JupyterLite app

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "@lumino/coreutils": "^2.2.1",
         "@lumino/messaging": "^2.0.3",
         "@lumino/widgets": "^2.7.1",
-        "@types/jsdom": "^21.1.1",
+        "@types/jsdom": "21.1.1",
         "typescript": "5.1.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "@lumino/messaging": "^2.0.3",
         "@lumino/widgets": "^2.7.1",
         "@types/jsdom": "^21.1.1",
-        "typescript": "4.9.5",
+        "typescript": "5.1.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "lib0": "0.2.105"
@@ -139,7 +139,7 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
-        "typescript": "4.9.5",
+        "typescript": "^5.1.6",
         "yjs": "^13.5.0"
     },
     "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
         "@lumino/coreutils": "^2.2.1",
         "@lumino/messaging": "^2.0.3",
         "@lumino/widgets": "^2.7.1",
-        "@types/jsdom": "^21.0.0",
+        "@types/jsdom": "^21.1.1",
         "typescript": "4.9.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
-        "typescript": "^5.1.6",
+        "typescript": "5.1.6",
         "yjs": "^13.5.0"
     },
     "sideEffects": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,7 +3449,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsdom@npm:^21.0.0":
+"@types/jsdom@npm:^21.1.1":
   version: 21.1.7
   resolution: "@types/jsdom@npm:21.1.7"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,14 +3449,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsdom@npm:^21.1.1":
-  version: 21.1.7
-  resolution: "@types/jsdom@npm:21.1.7"
+"@types/jsdom@npm:21.1.1":
+  version: 21.1.1
+  resolution: "@types/jsdom@npm:21.1.1"
   dependencies:
     "@types/node": "*"
     "@types/tough-cookie": "*"
     parse5: ^7.0.0
-  checksum: b7465d5a471ed4e68a54e2639c534d364134674598687be69645736731215e7407fe37a4af66dc616ef03be9c5515cb355df2eda5c8080146c05bd569ea8810d
+  checksum: 7450d6e23aa31b837a1682f0e59b06838aacca85c9d030035f40e21d559169c773aee5cee9244f23c3004b78f7064f0c540ceb808d2f187deb3140f2b0449dee
   languageName: node
   linkType: hard
 
@@ -7821,7 +7821,7 @@ __metadata:
     stylelint-config-standard: ^34.0.0
     stylelint-csstree-validator: ^3.0.0
     stylelint-prettier: ^4.0.0
-    typescript: ^5.1.6
+    typescript: 5.1.6
     yjs: ^13.5.0
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -7821,7 +7821,7 @@ __metadata:
     stylelint-config-standard: ^34.0.0
     stylelint-csstree-validator: ^3.0.0
     stylelint-prettier: ^4.0.0
-    typescript: 4.9.5
+    typescript: ^5.1.6
     yjs: ^13.5.0
   languageName: unknown
   linkType: soft
@@ -10586,23 +10586,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:5.1.6":
+  version: 5.1.6
+  resolution: "typescript@npm:5.1.6"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
+"typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>":
+  version: 5.1.6
+  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
+  checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Trying to debug failing snapshot tests in #184 