### PR TITLE
Make the PR builds and release builds use the same reusable actions

### DIFF
--- a/.github/build-app/action.yml
+++ b/.github/build-app/action.yml
@@ -1,0 +1,80 @@
+name: Build the jupyterlite app
+
+inputs:
+  mode:
+    description: '"test" or "prod"'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      with:
+        python-version: '3.11'
+
+    - name: Install micromamba
+      uses: mamba-org/setup-micromamba@b09ef9b599704322748535812ca03efb2625677b # v2.0.5
+
+    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        name: extension-artifacts
+
+    - name: Install the dependencies
+      run: |
+        cd lite
+        pip install -r requirements.txt
+
+    - name: Install Jupyter Everywhere extension
+      run: |
+        pip install jupytereverywhere*.whl
+
+    - name: Install jlpm
+      run: |
+        set -eux
+        python -m pip install "jupyterlab>=4.0.0,<5"
+
+    - name: Build the JupyterLite app in ${{ inputs.mode }} mode
+      env:
+        MATRIX_MODE: ${{ inputs.mode }}
+      run: |
+        cd lite
+        if [[ "${MATRIX_MODE}" == "prod" ]]; then
+          echo "Building JupyterLite app in production mode"
+          bash ../.github/inject-gh-pages-config.sh
+        else
+          echo "Building JupyterLite app in test mode"
+          bash ../ui-tests/inject-test-config.sh
+        fi
+        cd ..
+        jlpm install
+        jlpm build:all
+
+    - name: Upload artifact (${{ inputs.mode }})
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: lite-app-${{ inputs.mode }}
+        path: ./dist
+        if-no-files-found: error
+
+    - name: Upload GitHub Pages artifact for production mode
+      if: inputs.mode == 'prod'
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      with:
+        path: ./dist
+
+    - name: Leave instructions for testing
+      if: inputs.mode == 'prod'
+      run: |
+        echo "### JupyterLite App is ready" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo 'To test it locally, download the `lite-app-prod` artifact and run' >> $GITHUB_STEP_SUMMARY
+        echo '```bash' >> $GITHUB_STEP_SUMMARY
+        echo "rm -r lite-app-prod" >> $GITHUB_STEP_SUMMARY
+        echo "unzip lite-app-prod.zip -d lite-app" >> $GITHUB_STEP_SUMMARY
+        echo "cd lite-app" >> $GITHUB_STEP_SUMMARY
+        echo "python -m http.server -b 127.0.0.1" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo 'And navigate to http://127.0.0.1:8000/' >> $GITHUB_STEP_SUMMARY
+        echo 'Press ctrl + c to stop the server.' >> $GITHUB_STEP_SUMMARY

--- a/.github/build-extension/action.yml
+++ b/.github/build-extension/action.yml
@@ -1,0 +1,42 @@
+name: Build the jupyterlite-extension wheel and sdist
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@affc83be6020d529b9368cd4d63e467877606600 # v1
+
+    - name: Install dependencies
+      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+
+    - name: Restore Playwright browsers cache
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      with:
+        path: /home/runner/.cache/ms-playwright
+        key: playwright-browsers-${{ runner.os }}-v1
+        restore-keys: |
+          playwright-browsers-${{ runner.os }}-
+
+    - name: Build the extension
+      run: |
+        set -eux
+        python -m pip install .[test]
+
+        jupyter labextension list
+        jupyter labextension list 2>&1 | grep -ie "jupytereverywhere.*OK"
+        JLAB_BROWSER_TYPE=firefox python -m jupyterlab.browser_check
+
+    - name: Package the extension
+      run: |
+        set -eux
+
+        pip install build
+        python -m build
+        pip uninstall -y "jupytereverywhere" jupyterlab
+
+    - name: Upload extension packages
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: extension-artifacts
+        path: dist/jupytereverywhere*
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,57 +42,19 @@ jobs:
         set -eux
         jlpm run test
 
-  build:
-    name: Build JupyterLite extension
+  build-extension:
+    name: Build the jupyterlite-extension wheel
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      with:
-        persist-credentials: false
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - uses: ./.github/build-extension
 
-    - name: Base Setup
-      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@affc83be6020d529b9368cd4d63e467877606600 # v1
-
-    - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
-
-    - name: Restore Playwright browsers cache
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-      with:
-        path: /home/runner/.cache/ms-playwright
-        key: playwright-browsers-${{ runner.os }}-v1
-        restore-keys: |
-          playwright-browsers-${{ runner.os }}-
-
-    - name: Build the extension
-      run: |
-        set -eux
-        python -m pip install .[test]
-
-        jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jupytereverywhere.*OK"
-        JLAB_BROWSER_TYPE=firefox python -m jupyterlab.browser_check
-
-    - name: Package the extension
-      run: |
-        set -eux
-
-        pip install build
-        python -m build
-        pip uninstall -y "jupytereverywhere" jupyterlab
-
-    - name: Upload extension packages
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: extension-artifacts
-        path: dist/jupytereverywhere*
-        if-no-files-found: error
-
-  lite:
-    name: Build JupyterLite app (${{ matrix.mode }})
-    needs: build
+  build-app:
+    name: Build the JupyterLite app (${{ matrix.mode }})
+    needs: build-extension
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -103,85 +65,17 @@ jobs:
       pull-requests: write
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      with:
-        persist-credentials: false
-
-    - name: Setup Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-      with:
-        python-version: '3.11'
-
-    - name: Install micromamba
-      uses: mamba-org/setup-micromamba@b09ef9b599704322748535812ca03efb2625677b # v2.0.5
-
-    - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-      with:
-        name: extension-artifacts
-
-    - name: Install the dependencies
-      run: |
-        cd lite
-        pip install -r requirements.txt
-
-    - name: Install Jupyter Everywhere extension
-      run: |
-        pip install jupytereverywhere*.whl
-
-    - name: Install jlpm
-      run: |
-        set -eux
-        python -m pip install "jupyterlab>=4.0.0,<5"
-
-    - name: Build the JupyterLite app in ${{ matrix.mode }} mode
-      env:
-        MATRIX_MODE: ${{ matrix.mode }}
-      run: |
-        cd lite
-        if [[ "${MATRIX_MODE}" == "prod" ]]; then
-          echo "Building JupyterLite app in production mode"
-          bash ../.github/inject-gh-pages-config.sh
-        else
-          echo "Building JupyterLite app in test mode"
-          bash ../ui-tests/inject-test-config.sh
-        fi
-        cd ..
-        jlpm install
-        jlpm build:all
-
-    - name: Upload artifact (${{ matrix.mode }})
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: lite-app-${{ matrix.mode }}
-        path: ./dist
-        if-no-files-found: error
-
-    - name: Upload GitHub Pages artifact for production mode
-      if: matrix.mode == 'prod'
-      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
-      with:
-        path: ./dist
-
-    - name: Leave instructions for testing
-      if: matrix.mode == 'prod'
-      run: |
-        echo "### JupyterLite App is ready" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo 'To test it locally, download the `lite-app-prod` artifact and run' >> $GITHUB_STEP_SUMMARY
-        echo '```bash' >> $GITHUB_STEP_SUMMARY
-        echo "rm -r lite-app-prod" >> $GITHUB_STEP_SUMMARY
-        echo "unzip lite-app-prod.zip -d lite-app" >> $GITHUB_STEP_SUMMARY
-        echo "cd lite-app" >> $GITHUB_STEP_SUMMARY
-        echo "python -m http.server -b 127.0.0.1" >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo 'And navigate to http://127.0.0.1:8000/' >> $GITHUB_STEP_SUMMARY
-        echo 'Press ctrl + c to stop the server.' >> $GITHUB_STEP_SUMMARY
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - uses: ./.github/build-app
+        with:
+          mode: ${{ matrix.mode }}
 
   deploy:
     name: Deploy to GitHub Pages and Netlify
-    needs: lite
+    needs: build-app
     if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
@@ -199,7 +93,7 @@ jobs:
 
   deploy-netlify:
     name: Deploy to Netlify
-    needs: lite
+    needs: build-app
     if: github.ref == 'refs/heads/main'
 
     runs-on: ubuntu-latest
@@ -221,7 +115,7 @@ jobs:
 
   test_isolated:
     name: Isolated extension test
-    needs: build
+    needs: build-extension
     runs-on: ubuntu-latest
 
     steps:
@@ -249,7 +143,7 @@ jobs:
 
   integration-tests:
     name: Integration tests
-    needs: lite
+    needs: build-app
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,88 +13,36 @@ env:
 permissions: {}
 
 jobs:
-  build-python-distributions:
-    name: Build sdist and wheel
+  build-extension:
+    name: Build the jupyterlite-extension wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+      - uses: ./.github/build-extension
+
+  build-app:
+    name: Build the JupyterLite app
+    needs: build-extension
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: ./.github/build-app
         with:
-          python-version: '3.11'
-
-      - name: Install jlpm
-        run: pip install "jupyterlab>=4.0.0,<5"
-
-      - name: Build the extension artifacts
-        run: pipx run build --outdir distributions
-
-      - name: Upload the extension artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: sdist-and-wheel
-          path: distributions/jupytereverywhere*
-          if-no-files-found: error
-
-  build-jupyterlite-app:
-    name: Build JupyterLite deployment
-    needs: build-python-distributions
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: '3.11'
-
-      - name: Install micromamba
-        uses: mamba-org/setup-micromamba@b09ef9b599704322748535812ca03efb2625677b # v2.0.5
-
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: sdist-and-wheel
-          path: distributions
-
-      - name: Install the dependencies
-        run: |
-          pip install distributions/jupytereverywhere*.whl
-          pip install "jupyterlab>=4.0.0,<5"
-          pip install -r lite/requirements.txt
-
-      - name: Build JupyterLite app
-        run: |
-          set -eux
-          cd lite
-          # Inject production build configuration
-          bash ../.github/inject-gh-pages-config.sh
-          cd ..
-          jlpm install
-          jlpm build:all
-
-      - name: Create archive of JupyterLite app
-        run: tar -czf jupyterlite-app-release.tar.gz dist/
-
-      - name: Upload JupyterLite app artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: jupyterlite-app-release
-          path: jupyterlite-app-release.tar.gz
-          if-no-files-found: error
+          mode: prod
 
   release:
-    name: Upload to GitHub Release
+    name: Package and upload to GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-jupyterlite-app]
+    needs: build-app
     if: github.event_name == 'release' && github.event.action == 'published'
     permissions:
       # Required to upload artifacts to a GitHub release identifier
@@ -103,11 +51,20 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Download all artifacts
+      - name: Download the built app
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          path: upload
-          merge-multiple: true
+          name: lite-app-prod
+          path: dist/
+
+      - name: Create archive of JupyterLite app
+        run: tar -czf jupyterlite-app-release.tar.gz dist/
+
+      - name: Move everything into a single directory for attestation and publication
+        run: |
+          mkdir upload
+          mv dist/ upload/
+          mv jupyterlite-app-release.tar.gz upload/
 
       - name: Generate artifact attestations
         uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0


### PR DESCRIPTION
This PR makes the release workflow and the build workflows (triggered when PRs are made) use the same (reusable) build actions, reducing the chance that we have something go wrong during releases.

To do this, I broke the wheel/sdist builds into `.github/build-extension/action.yml`, and the lite app builds into `.github/build-app/action.yml`.

Closes #189.