### PR TITLE
Eagerly add kernel metadata before the kernel is initialised

### DIFF
--- a/lite/xeus-environment.yml
+++ b/lite/xeus-environment.yml
@@ -4,9 +4,7 @@ channels:
   - https://repo.prefix.dev/conda-forge
 dependencies:
   - xeus-python
-  # https://github.com/jupyter-xeus/xeus-r/commit/094d4e9d87b367f93c92792eee2950c89a171c0c
-  # Add https://github.com/jupyter-xeus/xeus-r/pull/161 until it is released
-  - git+https://github.com/jupyter-xeus/xeus-r.git@094d4e9d87b367f93c92792eee2950c89a171c0c
+  - xeus-r
   - numpy
   - pandas
   - scipy


### PR DESCRIPTION
This PR addresses the problem discussed with @ivonnem3 and @adamblake internally where we were receiving the HTTP 422 error code from the sharing service if we try to save/share the notebook before the Python/R kernels are initialised. I've added an `ensureLanguageMetadata` function that adds three fields if needed: the kernel language info (required to resolve the HTTP 422 error code), and the language info's `file_extension` and `version` to fix a further HTTP 500 error code.

I have not added a test for this change at this time; it is difficult to test it in its current state because we currently mock the API calls for the sharing service and #73 is not yet resolved. I've verified this manually by spinning up the sharing service locally and ensuring that the save and the share buttons generate a shareable URL before the kernel is loaded.