### PR TITLE
Switch back to the Pyodide kernel

### DIFF
--- a/lite/requirements.txt
+++ b/lite/requirements.txt
@@ -1,3 +1,3 @@
-jupyterlite==0.6.3
-jupyterlite-pyodide-kernel==0.6.0rc0
-jupyterlite-xeus==4.0.5
+jupyterlite==0.6.4
+jupyterlite-pyodide-kernel==0.6.1
+jupyterlite-xeus==4.1.2

--- a/lite/requirements.txt
+++ b/lite/requirements.txt
@@ -1,2 +1,3 @@
 jupyterlite==0.6.3
+jupyterlite-pyodide-kernel==0.6.0rc0
 jupyterlite-xeus==4.0.5

--- a/lite/xeus-environment.yml
+++ b/lite/xeus-environment.yml
@@ -1,16 +1,9 @@
-name: xeus-kernels
+name: xeus-kernel
 channels:
   - https://repo.mamba.pm/emscripten-forge
   - https://repo.prefix.dev/conda-forge
 dependencies:
-  - xeus-python
   - xeus-r
-  - numpy
-  - pandas
-  - scipy
-  - seaborn
-  - matplotlib
-  - scikit-learn
   - r-base
   # -r-tidyverse is not available yet due to upper pin on r-base, and
   # older r-base versions are not available on emscripten-forge, so we

--- a/lite/xeus-environment.yml
+++ b/lite/xeus-environment.yml
@@ -4,7 +4,6 @@ channels:
   - https://repo.prefix.dev/conda-forge
 dependencies:
   - xeus-r
-  - r-base
   # -r-tidyverse is not available yet due to upper pin on r-base, and
   # older r-base versions are not available on emscripten-forge, so we
   # install some of the tidyverse packages individually (except for

--- a/src/kernels.ts
+++ b/src/kernels.ts
@@ -18,6 +18,12 @@ export const KERNEL_DISPLAY_NAMES: Record<string, string> = {
 };
 
 /**
+ * List of kernels that will appear in the kernel switcher dropdown,
+ * i.e., for which we have an available factory.
+ */
+export const ACTIVE_KERNELS: readonly string[] = ['python', 'xr'];
+
+/**
  * Switch the notebook's kernel if it differs from the desired one.
  * @param panel The NotebookPanel to operate on
  * @param desiredKernel The kernel name to switch to (e.g. "python", "xr")

--- a/src/kernels.ts
+++ b/src/kernels.ts
@@ -7,11 +7,13 @@ export const KERNEL_URL_TO_NAME: Record<string, string> = {
 
 export const KERNEL_NAME_TO_URL: Record<string, string> = {
   python: 'python',
+  xpython: 'python',
   xr: 'r'
 };
 
 export const KERNEL_DISPLAY_NAMES: Record<string, string> = {
   python: 'Python',
+  xpython: 'Python',
   xr: 'R'
 };
 

--- a/src/kernels.ts
+++ b/src/kernels.ts
@@ -1,17 +1,17 @@
 import { NotebookPanel } from '@jupyterlab/notebook';
 
 export const KERNEL_URL_TO_NAME: Record<string, string> = {
-  python: 'xpython',
+  python: 'python',
   r: 'xr'
 };
 
 export const KERNEL_NAME_TO_URL: Record<string, string> = {
-  xpython: 'python',
+  python: 'python',
   xr: 'r'
 };
 
 export const KERNEL_DISPLAY_NAMES: Record<string, string> = {
-  xpython: 'Python',
+  python: 'Python',
   xr: 'R'
 };
 

--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -10,7 +10,7 @@ import { Commands } from '../commands';
 import { SharingService } from '../sharing-service';
 import { VIEW_ONLY_NOTEBOOK_FACTORY, IViewOnlyNotebookTracker } from '../view-only';
 import { KernelSwitcherDropdownButton } from '../ui-components/KernelSwitcherDropdownButton';
-import { KERNEL_URL_TO_NAME } from '../kernels';
+import { KERNEL_URL_TO_NAME, KERNEL_DISPLAY_NAMES } from '../kernels';
 
 /**
  * Maps the notebook content language to a kernel name. We currently
@@ -178,7 +178,7 @@ export const notebookPlugin: JupyterFrontEndPlugin<void> = {
         const kernelName = mapLanguageToKernel(content);
         content.metadata.kernelspec = {
           name: kernelName,
-          display_name: kernelName === 'python' ? 'Python 3' : 'R'
+          display_name: KERNEL_DISPLAY_NAMES[kernelName] ?? kernelName
         };
 
         const filename = `${(content.metadata?.name as string) || `Uploaded_${id}`}.ipynb`;

--- a/src/pages/notebook.tsx
+++ b/src/pages/notebook.tsx
@@ -15,10 +15,10 @@ import { KERNEL_URL_TO_NAME } from '../kernels';
 /**
  * Maps the notebook content language to a kernel name. We currently
  * only support Python and R notebooks, so this function maps them
- * to 'xpython' and 'xr' respectively. If the language is not recognized,
- * it defaults to 'xpython'.
+ * to 'python' and 'xr' respectively. If the language is not recognized,
+ * it defaults to 'python' (Pyodide).
  * @param content - The notebook content to map the language to a kernel name.
- * @returns - The kernel name as a string, either 'xpython' for Python or 'xr' for R.
+ * @returns - The kernel name as a string, either 'python' for Python or 'xr' for R.
  */
 function mapLanguageToKernel(content: INotebookContent): string {
   const rawLang =
@@ -29,7 +29,7 @@ function mapLanguageToKernel(content: INotebookContent): string {
   if (rawLang === 'r') {
     return 'xr';
   }
-  return 'xpython';
+  return 'python';
 }
 
 export const notebookPlugin: JupyterFrontEndPlugin<void> = {
@@ -151,7 +151,7 @@ export const notebookPlugin: JupyterFrontEndPlugin<void> = {
       try {
         const params = new URLSearchParams(window.location.search);
         const desiredKernelParam = params.get('kernel') || 'python';
-        const desiredKernel = KERNEL_URL_TO_NAME[desiredKernelParam] || 'xpython';
+        const desiredKernel = KERNEL_URL_TO_NAME[desiredKernelParam] || 'python';
 
         await commands.execute('notebook:create-new', {
           kernelName: desiredKernel
@@ -178,7 +178,7 @@ export const notebookPlugin: JupyterFrontEndPlugin<void> = {
         const kernelName = mapLanguageToKernel(content);
         content.metadata.kernelspec = {
           name: kernelName,
-          display_name: kernelName === 'xpython' ? 'Python 3' : 'R'
+          display_name: kernelName === 'python' ? 'Python 3' : 'R'
         };
 
         const filename = `${(content.metadata?.name as string) || `Uploaded_${id}`}.ipynb`;

--- a/src/ui-components/KernelSwitcherDropdownButton.tsx
+++ b/src/ui-components/KernelSwitcherDropdownButton.tsx
@@ -4,7 +4,7 @@ import { Message } from '@lumino/messaging';
 import { ToolbarButtonComponent, ReactWidget } from '@jupyterlab/ui-components';
 import { EverywhereIcons } from '../icons';
 import { CommandRegistry } from '@lumino/commands';
-import { KERNEL_DISPLAY_NAMES } from '../kernels';
+import { ACTIVE_KERNELS, KERNEL_DISPLAY_NAMES } from '../kernels';
 import { INotebookTracker } from '@jupyterlab/notebook';
 
 export class KernelSwitcherDropdownButton extends ReactWidget {
@@ -71,16 +71,17 @@ export class KernelSwitcherDropdownButton extends ReactWidget {
   }
 
   private _showMenu(): void {
-    const currentKernel = this._tracker.currentWidget?.sessionContext.session?.kernel?.name;
+    const currentKernel =
+      this._tracker.currentWidget?.sessionContext.session?.kernel?.name ?? undefined;
 
-    const allKernels = Object.keys(KERNEL_DISPLAY_NAMES);
+    const isCurrentActive =
+      typeof currentKernel === 'string' && ACTIVE_KERNELS.includes(currentKernel);
 
     // We order the kernels, so that the current kernel appears first
     // in the dropdown.
-    const orderedKernels = currentKernel
-      ? [currentKernel, ...allKernels.filter(k => k !== currentKernel)]
-      : allKernels;
-
+    const orderedKernels = isCurrentActive
+      ? [currentKernel!, ...ACTIVE_KERNELS.filter(k => k !== currentKernel)]
+      : ACTIVE_KERNELS;
     this._menu.clearItems();
 
     for (const kernel of orderedKernels) {

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -598,7 +598,7 @@ test.describe('Sharing and copying R and Python notebooks', () => {
 
     // Verify kernel is Python
     const kernelLabel = await page.locator('.je-KernelSwitcherButton').innerText();
-    await page.waitForTimeout(10000);
+    await page.waitForTimeout(2000);
     expect(kernelLabel.toLowerCase()).toContain('python');
   });
 });

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -466,7 +466,7 @@ test.describe('Kernel Switching', () => {
   });
 });
 
-test.skip('Should switch to R kernel and run R code', async ({ page }) => {
+test('Should switch to R kernel and run R code', async ({ page }) => {
   await page.goto('lab/index.html');
   await page.waitForSelector('.jp-NotebookPanel');
 

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -481,7 +481,7 @@ test('Should switch to R kernel and run R code', async ({ page }) => {
 
   const output = cell.locator('.jp-Cell-outputArea');
   await expect(output).toBeVisible({
-    timeout: 20000 // shouldn't take too long to run but just to be safe
+    timeout: 40000 // shouldn't take too long to run but just to be safe
   });
 
   const text = await output.textContent();

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -598,6 +598,7 @@ test.describe('Sharing and copying R and Python notebooks', () => {
 
     // Verify kernel is Python
     const kernelLabel = await page.locator('.je-KernelSwitcherButton').innerText();
+    await page.waitForTimeout(2000);
     expect(kernelLabel.toLowerCase()).toContain('python');
   });
 });

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -39,9 +39,9 @@ const PYTHON_TEST_NOTEBOOK: JSONObject = {
   ],
   metadata: {
     kernelspec: {
-      display_name: 'Python 3.13 (XPython)',
+      display_name: 'Python 3 (ipykernel)',
       language: 'python',
-      name: 'xpython'
+      name: 'python3'
     },
     language_info: {
       codemirror_mode: {

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -481,7 +481,7 @@ test('Should switch to R kernel and run R code', async ({ page }) => {
 
   const output = cell.locator('.jp-Cell-outputArea');
   await expect(output).toBeVisible({
-    timeout: 40000 // shouldn't take too long to run but just to be safe
+    timeout: 20000 // shouldn't take too long to run but just to be safe
   });
 
   const text = await output.textContent();

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -458,8 +458,8 @@ test.describe('Landing page', () => {
 
 test.describe('Kernel Switching', () => {
   test('Should open kernel switcher menu', async ({ page }) => {
-    const downloadButton = page.locator('.je-KernelSwitcherButton');
-    await downloadButton.click();
+    const dropdownButton = page.locator('.je-KernelSwitcherButton');
+    await dropdownButton.click();
     expect(
       await page.locator('.je-KernelSwitcherDropdownButton-menu').screenshot()
     ).toMatchSnapshot('kernel-switcher-menu.png');

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -598,6 +598,9 @@ test.describe('Sharing and copying R and Python notebooks', () => {
     // Wait for the notebook to switch to editable mode
     await page.waitForSelector('.jp-NotebookPanel');
 
+    // Wait for the kernel to initialise
+    await page.waitForTimeout(10000);
+
     // Verify kernel is Python
     const kernelLabel = await page.locator('.je-KernelSwitcherButton').innerText();
     expect(kernelLabel.toLowerCase()).toContain('python');

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -598,7 +598,6 @@ test.describe('Sharing and copying R and Python notebooks', () => {
 
     // Verify kernel is Python
     const kernelLabel = await page.locator('.je-KernelSwitcherButton').innerText();
-    await page.waitForTimeout(2000);
     expect(kernelLabel.toLowerCase()).toContain('python');
   });
 });

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -598,7 +598,7 @@ test.describe('Sharing and copying R and Python notebooks', () => {
 
     // Verify kernel is Python
     const kernelLabel = await page.locator('.je-KernelSwitcherButton').innerText();
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(10000);
     expect(kernelLabel.toLowerCase()).toContain('python');
   });
 });

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -552,6 +552,7 @@ test.describe('Leave confirmation', () => {
 });
 
 test.describe('Sharing and copying R and Python notebooks', () => {
+  test.describe.configure({ retries: 2 });
   test('Should create copy from view-only R notebook and keep R kernel', async ({ page }) => {
     await mockTokenRoute(page);
 

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -471,6 +471,7 @@ test('Should switch to R kernel and run R code', async ({ page }) => {
   await page.waitForSelector('.jp-NotebookPanel');
 
   await runCommand(page, 'jupytereverywhere:switch-kernel', { kernel: 'xr' });
+  await page.waitForTimeout(10000);
   await runCommand(page, 'notebook:insert-cell-below');
 
   const code = 'lm(mpg ~ wt + hp + disp + cyl, data=mtcars)';


### PR DESCRIPTION
The xeus-python kernel that was introduced in #144 has revealed a host of problems with its interoperability with the xeus-r kernel, and in some cases makes the R kernel runtime completely unresponsive, as discussed internally. This PR returns to the Pyodide kernel and drops the xeus-python-related configuration for now.

Closes #181
Closes #193