### PR TITLE
Revert "Use `memoryStorageDriver`"

### DIFF
--- a/lite/jupyter-lite.json
+++ b/lite/jupyter-lite.json
@@ -7,8 +7,6 @@
     "settingsStorageName": "JupyterEverywhere Storage",
     "exposeAppInBrowser": true,
     "showLoadingIndicator": true,
-    "enableMemoryStorage": true,
-    "contentsStorageDrivers": ["memoryStorageDriver"],
     "settingsOverrides": {
       "@jupyterlab/mainmenu-extension:plugin": {
         "menus": [


### PR DESCRIPTION
Testing if reverting JupyterEverywhere/jupyterlite-extension#85 could solve https://github.com/JupyterEverywhere/jupyterlite-extension/issues/230