### PR TITLE
Show the native "Leave site?" prompt when there is at least one uploaded file to the Files widget

### DIFF
--- a/src/pages/files.tsx
+++ b/src/pages/files.tsx
@@ -208,6 +208,7 @@ function FilesApp(props: IFilesAppProps) {
 
     const handler = (e: BeforeUnloadEvent) => {
       e.preventDefault();
+      return true;
     };
 
     window.addEventListener('beforeunload', handler);


### PR DESCRIPTION
Closes #222; this PR adds a guard to the Files widget to prevent the tab from closing immediately if there is at least one file that the user has uploaded. This is especially useful if the Files page is loaded directly, which does not interact with the Notebook tab (via #217).