### PR TITLE
Fix incorrect job name for GH Pages deployment job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           mode: ${{ matrix.mode }}
 
   deploy:
-    name: Deploy to GitHub Pages and Netlify
+    name: Deploy to GitHub Pages
     needs: build-app
     if: github.ref == 'refs/heads/main'
     permissions:


### PR DESCRIPTION
Netlify has its separate job, it isn't handled here.