### PR TITLE
Add the shareable ID to a notebook's URL on the first time it is shared

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,19 @@ function generateShareURL(notebookID: string): string {
   return `${baseUrl}?notebook=${notebookID}`;
 }
 
+/**
+ * Sets or updates the 'notebook' query parameter in the current URL to the given notebookID.
+ * If the parameter already exists with the same value, no change is made.
+ * @param notebookID - The ID of the notebook to set in the URL.
+ */
+function setNotebookParamInUrl(notebookID: string): void {
+  const url = new URL(window.location.href);
+  if (url.searchParams.get('notebook') !== notebookID) {
+    url.searchParams.set('notebook', notebookID);
+    window.history.replaceState({}, '', url.toString());
+  }
+}
+
 const manuallySharing = new WeakSet<NotebookPanel | ViewOnlyNotebookPanel>();
 
 /**
@@ -134,6 +147,17 @@ async function handleNotebookSharing(
 
       notebookPanel.context.model.fromJSON(notebookContent);
       await notebookPanel.context.save();
+
+      try {
+        const newReadable =
+          (notebookContent.metadata?.readableId as string | undefined) ??
+          (notebookContent.metadata?.sharedId as string | undefined);
+        if (newReadable) {
+          setNotebookParamInUrl(newReadable);
+        }
+      } catch (e) {
+        console.warn('Failed to update URL with shareable notebook ID:', e);
+      }
     }
 
     if (manual) {


### PR DESCRIPTION
This PR introduces the shareable URL as a URL parameter to the notebook URL when it first connects to the sharing service (on manual shares). As with other instances, we use `window.history.replaceState` to modify the URL without reloading the page. This guarantees that if an authored notebook is reloaded, the shareable link in the URL will still enable users to access a view-only version, from which they can create another copy and retain their work. To generate a new notebook, students will need manually remove the URL parameter themselves. As discussed, since the save interval is thirty seconds, there is a slight chance that changes made between these intervals might not be saved, but I would emphasise that we are already doing our best to prevent data loss through other methods (toast notifications, handling `beforeUnload` events, etc.).

Currently, this cannot be reliably tested until I complete #73, so I've skipped adding a test. However, I have tested this locally.

As discussed internally, this is slightly orthogonal to the sharing token being persisted using a cookie or the notebook content being saved to a cookie with an extremely short expiration time.

Closes #104. 