### PR TITLE
Disable `@jupyterlab/notebook-extension:open-with-no-kernel` 

### DIFF
--- a/lite/jupyter-lite.json
+++ b/lite/jupyter-lite.json
@@ -105,6 +105,7 @@
       "@jupyterlab/fileeditor-extension",
       "@jupyterlab/tooltip-extension:files",
       "@jupyterlab/filebrowser-extension",
+      "@jupyterlab/notebook-extension:open-with-no-kernel",
       "@jupyterlab/toc-extension",
 
       "@jupyterlab/notebook-extension:factory",


### PR DESCRIPTION
Reviewing https://github.com/JupyterEverywhere/jupyterlite-extension/pull/248 I noticed that there is an error in console:

<img width="735" height="268" alt="image" src="https://github.com/user-attachments/assets/02d03141-0e6b-47a1-a61a-d17475f42bbb" />

This is because we disable file browser. Since we do not use either we can disable this too.

Follow up to #227 