### PR TITLE
Fix warning banner clipping when the scrollbar activates on the Files widget

### DIFF
--- a/style/files-widget.css
+++ b/style/files-widget.css
@@ -13,6 +13,7 @@
   flex-direction: column;
   padding: 16px;
   gap: 16px;
+  overflow: hidden;
 }
 
 .je-FilesApp-content {


### PR DESCRIPTION
Closes #274; prevents the warning banner from being hidden in the viewport when the Files widget has lot of files.

| Before | After |
|--------|--------|
| <img width="997" height="261" alt="image" src="https://github.com/user-attachments/assets/27da3030-1b37-4cd8-92dc-115f1054e9fb" /> | <img width="997" height="261" alt="image" src="https://github.com/user-attachments/assets/6f976fa3-4d43-474b-886a-68caf552ef6a" /> | 