### PR TITLE
Use absolute paths for 404

### DIFF
--- a/templates/404-redirect.html
+++ b/templates/404-redirect.html
@@ -5,7 +5,7 @@
     <title>Not found</title>
     <script>
       (function () {
-        const url = new URL('../index.html', window.location.href);
+        const url = new URL('/lab/index.html', window.location.href);
         const params = new URLSearchParams(window.location.search);
         params.set('tab', '404');
         url.search = params.toString();
@@ -14,7 +14,7 @@
       })();
     </script>
     <noscript>
-      <meta http-equiv="refresh" content="0; url=../index.html?tab=404" />
+      <meta http-equiv="refresh" content="0; url=/lab/index.html?tab=404" />
     </noscript>
   </head>
   <body></body>


### PR DESCRIPTION
- Closes #273 

This is required given the backend configuration, but it is also a less error-prone way to handle redirects in general.

> Preview: https://pr-283.dev.jupytereverywhere.org/ (not working because https://github.com/JupyterEverywhere/infrastructure/issues/25)